### PR TITLE
remove hardcoded hashKey name, use value of key name passed to method

### DIFF
--- a/lib/models/model.js
+++ b/lib/models/model.js
@@ -170,25 +170,23 @@ var Model = function () {
       (0, _logger.debug)('= Model._filterOptions', JSON.stringify(options));
       var dbOptions = {};
       if (options.filters) {
-        (function () {
-          var attributeNamesMapping = {};
-          var attributeValuesMapping = {};
-          var filterExpressions = [];
-          Object.keys(options.filters).forEach(function (key) {
-            var attrName = '#' + key;
-            attributeNamesMapping[attrName] = key;
-            var conditions = options.filters[key];
-            Object.keys(conditions).forEach(function (operand) {
-              var value = conditions[operand];
-              var attrValue = ':' + key;
-              attributeValuesMapping[attrValue] = value;
-              filterExpressions.push(_this3._buildFilter(attrName, operand, [attrValue]));
-            });
+        var attributeNamesMapping = {};
+        var attributeValuesMapping = {};
+        var filterExpressions = [];
+        Object.keys(options.filters).forEach(function (key) {
+          var attrName = '#' + key;
+          attributeNamesMapping[attrName] = key;
+          var conditions = options.filters[key];
+          Object.keys(conditions).forEach(function (operand) {
+            var value = conditions[operand];
+            var attrValue = ':' + key;
+            attributeValuesMapping[attrValue] = value;
+            filterExpressions.push(_this3._buildFilter(attrName, operand, [attrValue]));
           });
-          dbOptions.ExpressionAttributeNames = attributeNamesMapping;
-          dbOptions.ExpressionAttributeValues = attributeValuesMapping;
-          dbOptions.FilterExpression = filterExpressions.join(' AND ');
-        })();
+        });
+        dbOptions.ExpressionAttributeNames = attributeNamesMapping;
+        dbOptions.ExpressionAttributeValues = attributeValuesMapping;
+        dbOptions.FilterExpression = filterExpressions.join(' AND ');
       }
       return dbOptions;
     }
@@ -318,7 +316,7 @@ var Model = function () {
         TableName: this.tableName,
         ScanIndexForward: this.scanForward
       };
-      var keyParams = this._buildKeyParams(value, options);
+      var keyParams = this._buildKeyParams(key, value, options);
       var dbOptions = this._buildOptions(options, params);
       return (0, _deepAssign2.default)(params, keyParams, dbOptions);
     }
@@ -342,10 +340,10 @@ var Model = function () {
     }
   }, {
     key: '_buildKeyParams',
-    value: function _buildKeyParams(hash) {
-      var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+    value: function _buildKeyParams(key, hash) {
+      var options = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
 
-      var hashKeyParams = this._buildHashKeyParams(hash, options);
+      var hashKeyParams = this._buildHashKeyParams(key, hash, options);
       var rangeKeyParams = this._buildRangeKeyParams(options);
       var keyCondition = [hashKeyParams.KeyConditionExpression, rangeKeyParams.KeyConditionExpression].filter(function (item) {
         return !!item;
@@ -356,10 +354,10 @@ var Model = function () {
     }
   }, {
     key: '_buildHashKeyParams',
-    value: function _buildHashKeyParams(hash) {
+    value: function _buildHashKeyParams(key, hash) {
       return {
         KeyConditionExpression: '#hkey = :hvalue',
-        ExpressionAttributeNames: { '#hkey': this.hashKey },
+        ExpressionAttributeNames: { '#hkey': key || this.hashKey },
         ExpressionAttributeValues: { ':hvalue': hash }
       };
     }
@@ -608,14 +606,12 @@ var Model = function () {
           } else {
             (0, _logger.debug)('= Model._client', method, 'Success');
             if (data.UnprocessedItems && Object.keys(data.UnprocessedItems).length > 0 && retries < _this13.maxRetries) {
-              (function () {
-                (0, _logger.debug)('= Model._client', method, 'Some unprocessed items... Retrying', JSON.stringify(data));
-                var retryParams = { RequestItems: data.UnprocessedItems };
-                var delay = _this13.retryDelay * Math.pow(2, retries);
-                setTimeout(function () {
-                  resolve(_this13._client(method, retryParams, retries + 1));
-                }, delay);
-              })();
+              (0, _logger.debug)('= Model._client', method, 'Some unprocessed items... Retrying', JSON.stringify(data));
+              var retryParams = { RequestItems: data.UnprocessedItems };
+              var delay = _this13.retryDelay * Math.pow(2, retries);
+              setTimeout(function () {
+                resolve(_this13._client(method, retryParams, retries + 1));
+              }, delay);
             } else {
               (0, _logger.debug)('= Model._client', method, 'resolving', JSON.stringify(data));
               resolve(data);

--- a/src/models/model.js
+++ b/src/models/model.js
@@ -275,7 +275,7 @@ class Model {
   static _buildHashKeyParams(key, hash) {
     return {
       KeyConditionExpression: '#hkey = :hvalue',
-      ExpressionAttributeNames: { '#hkey': key },
+      ExpressionAttributeNames: { '#hkey': key || this.hashKey},
       ExpressionAttributeValues: { ':hvalue': hash }
     };
   }

--- a/src/models/model.js
+++ b/src/models/model.js
@@ -244,7 +244,7 @@ class Model {
       TableName: this.tableName,
       ScanIndexForward: this.scanForward
     };
-    const keyParams = this._buildKeyParams(value, options);
+    const keyParams = this._buildKeyParams(key, value, options);
     const dbOptions = this._buildOptions(options, params);
     return deepAssign(params, keyParams, dbOptions);
   }
@@ -260,8 +260,8 @@ class Model {
     });
   }
 
-  static _buildKeyParams(hash, options = {}) {
-    const hashKeyParams = this._buildHashKeyParams(hash, options);
+  static _buildKeyParams(key, hash, options = {}) {
+    const hashKeyParams = this._buildHashKeyParams(key, hash, options);
     const rangeKeyParams = this._buildRangeKeyParams(options);
     const keyCondition = [
       hashKeyParams.KeyConditionExpression,
@@ -272,10 +272,10 @@ class Model {
     return params;
   }
 
-  static _buildHashKeyParams(hash) {
+  static _buildHashKeyParams(key, hash) {
     return {
       KeyConditionExpression: '#hkey = :hvalue',
-      ExpressionAttributeNames: { '#hkey': this.hashKey },
+      ExpressionAttributeNames: { '#hkey': key },
       ExpressionAttributeValues: { ':hvalue': hash }
     };
   }


### PR DESCRIPTION
The name of the hashKey was hardcoded in _buildKeyParams
```
 ExpressionAttributeNames: { '#hkey': this.hashKey },
```
This prevented methods like ``` allBy(key, value, options = {}) ``` from using GSIs with different hashKey names.

Use case that caused me to fine the issue:
```
.allBy('GSI-HashKey-Name', keyVal, { 'indexName': 'Index-Name', 'limit': 50 })
```

The generated query was always using the model primary hashKey name and not the passed GSI hashKey name.

---------
Thanks for sharing this project.  I have found it very useful and like the approach you all have taken. 
👍



