### PR TITLE
_validateSchema should ignore additional properties

### DIFF
--- a/src/models/model.js
+++ b/src/models/model.js
@@ -462,7 +462,7 @@ class Model {
 
   static _validateSchema(schema, model) {
     if (!this.schema) return true;
-    const result = Joi.validate(model, schema);
+    const result = Joi.validate(model, schema, { allowUnknown: true });
     return !result.error;
   }
 


### PR DESCRIPTION
This method return false when there are additional properties set to the object. For instance:

```
const schema = Joi.object({
      userId: Joi.string().required()
    });
```

`this._validateSchema(schema, {userId: 'test', 'john': 'doe'})` will return false, which is not true. The object should be valid.